### PR TITLE
Fix createGroup() to not create folders outside the container

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/s3/N5AmazonS3Writer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/s3/N5AmazonS3Writer.java
@@ -157,14 +157,15 @@ public class N5AmazonS3Writer extends N5AmazonS3Reader implements N5Writer {
 	@Override
 	public void createGroup(final String pathName) throws IOException {
 
-		final Path path = Paths.get(getFullPath(pathName));
-		for (int i = 0; i < path.getNameCount(); ++i) {
-			final String subgroup = path.subpath(0, i + 1).toString();
+		final Path groupPath = Paths.get(removeLeadingSlash(pathName));
+		for (int i = 0; i < groupPath.getNameCount(); ++i) {
+			final String parentGroupPath = groupPath.subpath(0, i + 1).toString();
+			final String fullParentGroupPath = getFullPath(parentGroupPath);
 			final ObjectMetadata metadata = new ObjectMetadata();
 			metadata.setContentLength(0);
 			s3.putObject(
 					bucketName,
-					replaceBackSlashes(addTrailingSlash(removeLeadingSlash(subgroup))),
+					replaceBackSlashes(addTrailingSlash(removeLeadingSlash(fullParentGroupPath))),
 					new ByteArrayInputStream(new byte[0]),
 					metadata);
 		}

--- a/src/test/java/org/janelia/saalfeldlab/n5/s3/AbstractN5AmazonS3ContainerPathTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/s3/AbstractN5AmazonS3ContainerPathTest.java
@@ -43,7 +43,7 @@ public abstract class AbstractN5AmazonS3ContainerPathTest extends AbstractN5Amaz
 
         rampDownAfterClass();
         Assert.assertTrue(s3.doesBucketExistV2(testBucketName));
-        Assert.assertTrue(s3.doesObjectExist(testBucketName, "test/"));
+        Assert.assertFalse(s3.doesObjectExist(testBucketName, "test/"));
         new N5AmazonS3Writer(s3, testBucketName).remove();
         Assert.assertFalse(s3.doesBucketExistV2(testBucketName));
     }


### PR DESCRIPTION
There are no real folders in S3, and the official way to mimic them is to create an empty object ending with `/`. This is what we're doing in `createGroup()` to actually create intermediate groups along the path to the requested group, such as `a/` and `a/b/` for the group `/a/b/c`.
This is not necessary, and the method `exists()` actually uses a different way of checking whether a group exists or not, but for other use-cases it could be quite useful to create intermediate directories explicitly.

The current implementation of `createGroup()` tries to create all directories in the path starting from the bucket root. But if the container is located not at the bucket root but somewhere at a deeper level, such as `s3://bucket/dir/container.n5`, we do not want to attempt to write outside the container, i.e. the bucket root and the directory `dir` should not be modified. Sometimes it may not be even possible, for example, if the user is authorized to work only with the given container and doesn't have write access to the rest of the bucket. This PR fixes this, so that the directories outside the container are not modified.