### PR TITLE
fix: output stream on LockedWriters where not closing themselves

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/s3/AmazonS3KeyValueAccess.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/s3/AmazonS3KeyValueAccess.java
@@ -609,7 +609,11 @@ public class AmazonS3KeyValueAccess implements KeyValueAccess {
 		public OutputStream newOutputStream() throws IOException {
 
 			checkWritable();
-			return new S3OutputStream();
+			final S3OutputStream s3Out = new S3OutputStream();
+			synchronized (resources) {
+				resources.add(s3Out);
+			}
+			return s3Out;
 		}
 
 		@Override


### PR DESCRIPTION
When getting a new S3OutputStream for writing, the object is actually written to s3 when it is `closed()`. However, the LockedChannel doesn't not keep track of and close the generated S3OutputStreams when the channel itself is closed.

In practice, this only is an issue with BloscCompression, because all the other compressors call close on the S3OutputStream after receiving them, and writing to them. BloscCompression does not though.

This ensures `close()` is called on all `S3OutputStream`s generated by the `AmazonS3KeyValueAccess`.

Not part of this PR, but some more thought should go into the Compressor implementations, to determine whether they should close the output stream they are passed or not. My current thought is that the KVAs should be responsible for closing the OutputStreams that they create. And the underlying calls to write into them by the Compressors should write into them, but not close.