### PR TITLE
Fix handling a port number in URI

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/s3/AmazonS3Utils.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/s3/AmazonS3Utils.java
@@ -126,7 +126,7 @@ public class AmazonS3Utils {
 			// if AmazonS3URI does not like the form of the uri
 			try {
 				final URI asURI = new URI(uri);
-				final URI endpointUri = new URI(asURI.getScheme(), asURI.getAuthority(), null, null);
+				final URI endpointUri = new URI(asURI.getScheme(), asURI.getAuthority(), null, null, null);
 				return createS3(AmazonS3Utils.getS3Bucket(uri), s3Credentials, new AwsClientBuilder.EndpointConfiguration(endpointUri.toString(), null), null);
 			} catch (final URISyntaxException e1) {
 				throw new N5Exception("Could not create s3 client from uri: " + uri, e1);


### PR DESCRIPTION
Properly handle a URI with port number.
The constructor that takes the authority needs one more argument.

```java
// With previous implementation, this constructor is called
    public URI(String scheme, String host, String path, String fragment)
        throws URISyntaxException
    {
        this(scheme, null, host, -1, path, null, fragment);
    }

// With this PR, this constructor is called
    public URI(String scheme,
               String authority,
               String path, String query, String fragment)
        throws URISyntaxException
    {
        String s = toString(scheme, null,
                            authority, null, null, -1,
                            path, query, fragment);
        checkPath(s, scheme, path);
        new Parser(s).parse(false);
    }
```