### PR TITLE
Update a testUriParsing

### DIFF
--- a/src/test/java/org/janelia/saalfeldlab/n5/s3/AmazonS3UtilsTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/s3/AmazonS3UtilsTest.java
@@ -35,9 +35,11 @@ public class AmazonS3UtilsTest {
 		for (String prefix : prefixes)
 			for (String bucket : buckets)
 				for (String path : paths) {
-					URI uri = new URI(prefix + bucket + "/" + path);
+					String uriString = prefix + bucket + "/" + path;
+					URI uri = new URI(uriString);
 					assertEquals("bucket from uri", bucket, AmazonS3Utils.getS3Bucket(uri));
 					assertEquals("key from uri", path, AmazonS3Utils.getS3Key(uri));
+					AmazonS3Utils.createS3(uriString);
 				}
 
 	}


### PR DESCRIPTION
AmazonS3Utils.createS3(uriString) gives the following exception when it fails.

Related to: https://github.com/saalfeldlab/n5-aws-s3/pull/29#issuecomment-2062069546

```
org.janelia.saalfeldlab.n5.N5Exception: Could not create s3 client from uri: http://localhost:8001/zarr-n5-demo/
        at org.janelia.saalfeldlab.n5.s3.AmazonS3Utils.createS3(AmazonS3Utils.java:132)
        at org.janelia.saalfeldlab.n5.s3.AmazonS3Utils.createS3(AmazonS3Utils.java:117)
        at org.janelia.saalfeldlab.n5.s3.AmazonS3UtilsTest.testUriParsing(AmazonS3UtilsTest.java:42)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
        at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
        at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
        at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:93)
        at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:40)
        at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:529)
        at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:757)
        at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:452)
        at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:210)
Caused by: java.net.URISyntaxException: Malformed IPv6 address at index 8: http://[localhost:8001]
        at java.base/java.net.URI$Parser.fail(URI.java:2976)
        at java.base/java.net.URI$Parser.parseIPv6Reference(URI.java:3593)
        at java.base/java.net.URI$Parser.parseServer(URI.java:3343)
        at java.base/java.net.URI$Parser.parseAuthority(URI.java:3279)
        at java.base/java.net.URI$Parser.parseHierarchical(URI.java:3221)
        at java.base/java.net.URI$Parser.parse(URI.java:3177)
        at java.base/java.net.URI.<init>(URI.java:708)
        at java.base/java.net.URI.<init>(URI.java:809)
        at org.janelia.saalfeldlab.n5.s3.AmazonS3Utils.createS3(AmazonS3Utils.java:129)
        ... 28 more
```